### PR TITLE
fix: 删除路由改写为事务，并且先判断是否删除RBAC能否成功

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,34 @@
+server:
+  port: 8899
+  address: 127.0.0.1
+  name: go-easy-admin
+  # # 生产环境建议使用 release，debug：可以使用debug模式
+  model: release
+  adminUser: admin
+  adminPwd: 25285442ebc7d3a0c20047e01d341c31
+
+# 数据库配置
+mysql:
+  DbHost: 47.92.196.70
+  DbPort: 3306
+  # 数据库名称 需要提前创建好
+  DbName: go_easy_admin
+  DbUser: root
+  DbPwd: v|+(ah@bF3dyN
+  MaxIdleConns: 10
+  MaxOpenConns: 100
+  # 是否开启debug，1 开启 0 关闭
+  ActiveDebug: 0
+
+# 密码加密
+aes:
+  key: go-easy-admin
+
+jwt:
+  realm: go-easy-admin
+  # jwt加密因子
+  key: anruo
+  #  jwt token过期时间 单位为小时
+  timeout: 100
+  # jwt token刷新时间 单位为小时
+  maxRefresh: 1

--- a/pkg/controller/system/user.go
+++ b/pkg/controller/system/user.go
@@ -10,7 +10,6 @@ package system
 import (
 	"context"
 	"errors"
-
 	"github.com/jinzhu/copier"
 	"gorm.io/gorm"
 


### PR DESCRIPTION
该地方原先删除路由，在删除RBAC；如果路由删除成功，RBAC没有记录，删除提示没有找到记录，返回依然是提示错误，但是路由确删除成功很不妥。